### PR TITLE
legal: use open-ended copyright year range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 Mutagen IO, Inc.
+Copyright (c) 2020-present Mutagen IO, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This pull request changes the copyright year range to an open-ended range. The first year is the only year that matters anyway.
