### PR TITLE
sidecar: added container_name configuration option

### DIFF
--- a/pkg/mutagen/configuration.go
+++ b/pkg/mutagen/configuration.go
@@ -11,6 +11,8 @@ type sidecarConfiguration struct {
 	Features string `mapstructure:"features"`
 	// Restart is the restart policy for the sidecar container.
 	Restart string `mapstructure:"restart"`
+	// ContainerName is the name given to the sidecar container.
+	ContainerName string `mapstructure:"container_name"`
 }
 
 // forwardingConfiguration encodes a forwarding session specification.

--- a/pkg/mutagen/liaison.go
+++ b/pkg/mutagen/liaison.go
@@ -492,6 +492,9 @@ func (l *Liaison) processProject(project *types.Project) error {
 		}
 		l.mutagenService.Restart = xMutagen.Sidecar.Restart
 	}
+	if xMutagen.Sidecar.ContainerName != "" {
+		l.mutagenService.ContainerName = xMutagen.Sidecar.ContainerName
+	}
 
 	// Store session specifications.
 	l.forwarding = forwardingSpecifications


### PR DESCRIPTION
<!--

Thanks for the pull request! Before submitting, please ensure that your commits
adhere to the guidelines in CONTRIBUTING.md. Pull requests that do not meet
these guidelines cannot be merged.

If you're not quite ready for a final review, please feel free to open a draft
pull request.

-->

**What does this pull request do and why is it needed?**

This change was discussed in Mutagen Slack. This PR adds a container_name option to the sidecar config. This allows users to give a friendlier name to the sidecar container. The friendly name can be leveraged in e.g. monitoring tools.

**Any other notes for the review process?**

There are no checks for conflicting container names. If you attempt to run mutagen-compose with conflicting container names, the mutagen sidecar and sync will start, but the docker daemon will return a conflict error for the compose project. Is this something we want to attempt to address inside mutagen-compose?
