### PR TITLE
all: update to Mutagen v0.15.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/compose/v2 v2.6.0
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mutagen-io/mutagen v0.15.1
+	github.com/mutagen-io/mutagen v0.15.2
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434 h1:PYeqqury0vV
 github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7 h1:0PaUmAw6e54jseSG0ob2U9P1p6p+Sppw3sanphmM4LY=
 github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7/go.mod h1:MyZ/hSGB6tVRgiUqOL62QdM31Sy+B8hvbA1roNTHmOc=
-github.com/mutagen-io/mutagen v0.15.1 h1:DGcuGrX5doZmfPhn2pXvjA6oq3ZlFHpUTsxk+sohGbQ=
-github.com/mutagen-io/mutagen v0.15.1/go.mod h1:/YzlgA/IDS3Qci79DhWlKGz3TVgDReNdXhRtQ3jQ7Hg=
+github.com/mutagen-io/mutagen v0.15.2 h1:2HOKo7eIBlI8uiO0zGAgwvtfLExO1PyfhE36B9gB3Iw=
+github.com/mutagen-io/mutagen v0.15.2/go.mod h1:/YzlgA/IDS3Qci79DhWlKGz3TVgDReNdXhRtQ3jQ7Hg=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the underlying Mutagen version to v0.15.2.
