### PR TITLE
deps: update Mutagen to v0.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/compose/v2 v2.11.2
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mutagen-io/mutagen v0.16.0-rc1
+	github.com/mutagen-io/mutagen v0.16.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1081,8 +1081,8 @@ github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434 h1:PYeqqury0vV
 github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7 h1:0PaUmAw6e54jseSG0ob2U9P1p6p+Sppw3sanphmM4LY=
 github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7/go.mod h1:MyZ/hSGB6tVRgiUqOL62QdM31Sy+B8hvbA1roNTHmOc=
-github.com/mutagen-io/mutagen v0.16.0-rc1 h1:sP7gxAc8mksePYAd/KJNi/Grr9w4UZH4Be3tD9HU/Q0=
-github.com/mutagen-io/mutagen v0.16.0-rc1/go.mod h1:xeWmsuovD8Qr2ZtWIkZVO+akPP68YEh5e9yPuBOE7dA=
+github.com/mutagen-io/mutagen v0.16.0 h1:mvWOw71yiWtKHa434/0mVX+beVxzL8NXqq0xRw4XTFY=
+github.com/mutagen-io/mutagen v0.16.0/go.mod h1:xeWmsuovD8Qr2ZtWIkZVO+akPP68YEh5e9yPuBOE7dA=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the Mutagen dependency to v0.16.0.
