### PR TITLE
deps: update to Go 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.20.0'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -68,11 +68,14 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        goversion: ['1.19.5', '1.20.0']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: ${{ matrix.goversion }}
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/analyze.sh
       - run: scripts/ci/test.sh
@@ -85,7 +88,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.20.0'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/analyze.sh


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates to Go toolchain to version 1.20.

Unlike previous Go toolchain updates, we're going to continue supporting (and testing) the previous Go release as well.
