### PR TITLE
all: prepare for v0.16.5 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - run: scripts/ci/setup_go.sh
       - run: scripts/ci/analyze.sh
       - run: scripts/ci/test.sh
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/analyze.sh

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/compose/v2 v2.15.1
 	github.com/docker/docker v20.10.20+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mutagen-io/mutagen v0.16.4
+	github.com/mutagen-io/mutagen v0.16.5
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434 h1:PYeqqury0vV
 github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7 h1:0PaUmAw6e54jseSG0ob2U9P1p6p+Sppw3sanphmM4LY=
 github.com/mutagen-io/gopass v0.0.0-20170602182606-9a121bec1ae7/go.mod h1:MyZ/hSGB6tVRgiUqOL62QdM31Sy+B8hvbA1roNTHmOc=
-github.com/mutagen-io/mutagen v0.16.4 h1:p+8t9FqJ0WPqPrvbMvX7iTWziJ1a6YneaE4VldVa0zs=
-github.com/mutagen-io/mutagen v0.16.4/go.mod h1:tZAhU0FIM0ZtFhlx1F4kzx2fZjNs0XAFHR4u8NLhJJ4=
+github.com/mutagen-io/mutagen v0.16.5 h1:mqMQFItJ6pJzKtVpQ3OJAH/g/TxW80mh+4lc4uxFEtI=
+github.com/mutagen-io/mutagen v0.16.5/go.mod h1:tZAhU0FIM0ZtFhlx1F4kzx2fZjNs0XAFHR4u8NLhJJ4=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the Mutagen dependency to v0.16.5 and the Go toolchain to 1.19.6.
