### PR TITLE
deps: update Go versions to 1.20.4 and 1.19.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.4'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        goversion: ['1.19.6', '1.20.1']
+        goversion: ['1.19.9', '1.20.4']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.4'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/analyze.sh

--- a/README.md
+++ b/README.md
@@ -59,16 +59,14 @@ For updates about the project and its releases, you can
 
 Mutagen Compose is built and tested on Windows, macOS, and Linux.
 
-| Tests                               | Report card                         | License                                   |
-| :---------------------------------: | :---------------------------------: | :---------------------------------------: |
-| [![Tests][tests-badge]][tests-link] | [![Report card][rc-badge]][rc-link] | [![License][license-badge]][license-link] |
+| Tests                               | Report card                         |
+| :---------------------------------: | :---------------------------------: |
+| [![Tests][tests-badge]][tests-link] | [![Report card][rc-badge]][rc-link] |
 
 [tests-badge]: https://github.com/mutagen-io/mutagen-compose/workflows/CI/badge.svg "Test status"
 [tests-link]: https://github.com/mutagen-io/mutagen-compose/actions "Test status"
 [rc-badge]: https://goreportcard.com/badge/github.com/mutagen-io/mutagen-compose "Report card status"
 [rc-link]: https://goreportcard.com/report/github.com/mutagen-io/mutagen-compose "Report card status"
-[license-badge]: https://img.shields.io/github/license/mutagen-io/mutagen-compose.svg "MIT licensed"
-[license-link]: LICENSE "MIT licensed"
 
 
 ## Contributing


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the Go versions used for builds and testing to 1.20.4 and 1.19.9.

It also removes a stale badge from the `README.md` file.
