### PR TITLE
deps: update to Mutagen v0.17.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/compose/v2 v2.15.1
 	github.com/docker/docker v20.10.20+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mutagen-io/mutagen v0.17.0
+	github.com/mutagen-io/mutagen v0.17.1
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434 h1:PYeqqury0vV
 github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c h1:c0xgZ8mF6PwiDc6aW2MEcdaCXxkt5K30kzylWqkT4oc=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c/go.mod h1:Q87jWQAqEC/UdnYLd+A0mfR9oZl5gk6g/xvxzTpwLv8=
-github.com/mutagen-io/mutagen v0.17.0 h1:DoAGXXCEiUWuFTcFjCm4t0fnQ2YCKPC+alxhuzFXwvU=
-github.com/mutagen-io/mutagen v0.17.0/go.mod h1:XEq4vBlgkdH3IPwipNqts8WwKrtxY1do9vq5EzOkoMs=
+github.com/mutagen-io/mutagen v0.17.1 h1:xfXTslalqrv5itF86M5aA2zX9xUKQrrNxZPLNA+z+7E=
+github.com/mutagen-io/mutagen v0.17.1/go.mod h1:XEq4vBlgkdH3IPwipNqts8WwKrtxY1do9vq5EzOkoMs=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the underlying Mutagen version to v0.17.1.

**Which issue(s) does this pull request address (if any)?**

This addresses [CVE-2023-30844](https://github.com/mutagen-io/mutagen/security/advisories/GHSA-jmp2-wc4p-wfh2) and [GHSA-fwj4-72fm-c93g](https://github.com/mutagen-io/mutagen/security/advisories/GHSA-fwj4-72fm-c93g).