### PR TITLE
deps: update Go and Mutagen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.4'
+          go-version: '1.20.5'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        goversion: ['1.19.9', '1.20.4']
+        goversion: ['1.19.10', '1.20.5']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.4'
+          go-version: '1.20.5'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/analyze.sh

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/compose/v2 v2.15.1
 	github.com/docker/docker v20.10.20+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mutagen-io/mutagen v0.17.1
+	github.com/mutagen-io/mutagen v0.17.2
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 )
@@ -88,7 +88,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8 // indirect
-	github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434 // indirect
+	github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc // indirect
 	github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -433,12 +433,12 @@ github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8 h1:NEBqH/oVnWBunxdrdy1vlyGior8smhC6jZjxlWSG2BU=
 github.com/mutagen-io/extstat v0.0.0-20210224131814-32fa3f057fa8/go.mod h1:ZHGnLARFvfv0lUb6FsAS+LJHt9CFemt7K+mWfkw8nVA=
-github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434 h1:PYeqqury0vVzjjUVO6dwtfA2HXOaPYgDclSgKX8u0gs=
-github.com/mutagen-io/fsevents v0.0.0-20180903111129-10556809b434/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
+github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc h1:yOGQ0Hc3NfOWYm9aaluKJEOZWEbpCPEm/TbPU87YumM=
+github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c h1:c0xgZ8mF6PwiDc6aW2MEcdaCXxkt5K30kzylWqkT4oc=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c/go.mod h1:Q87jWQAqEC/UdnYLd+A0mfR9oZl5gk6g/xvxzTpwLv8=
-github.com/mutagen-io/mutagen v0.17.1 h1:xfXTslalqrv5itF86M5aA2zX9xUKQrrNxZPLNA+z+7E=
-github.com/mutagen-io/mutagen v0.17.1/go.mod h1:XEq4vBlgkdH3IPwipNqts8WwKrtxY1do9vq5EzOkoMs=
+github.com/mutagen-io/mutagen v0.17.2 h1:LtHssy3qTTbVkJrZHr+X00y8uBfd2SszUB61ESzkay8=
+github.com/mutagen-io/mutagen v0.17.2/go.mod h1:TF/UsvJvdIKWFOPLGmZCvPVuezejIPj7ogSvZ499NeA=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates the following dependencies:

- Go to 1.20.5 and 1.19.10
    - These releases contain a fix for CVE-2023-29403
- Mutagen to v0.17.2
    - An incidental but important update has also occurred to the forked fsevents package used by Mutagen, which was previously colliding with the upstream package used by Docker Compose 2.17.0+.  This fix is a hack for the time being, but should be fairly robust until we can get back on the upstream fsevents package.  See mutagen-io/mutagen-compose#64 and mutagen-io/mutagen#452 for more information.

**Which issue(s) does this pull request address (if any)?**

This will help to unblock mutagen-io/mutagen-compose#64.
