### PR TITLE
ci: avoid validation of merge commits

### DIFF
--- a/scripts/ci/verify_commits.sh
+++ b/scripts/ci/verify_commits.sh
@@ -63,7 +63,7 @@ while read commit; do
 
     # Output a separator line.
     echo
-done < <(git rev-list "${VERIFY_COMMIT_START}..${VERIFY_COMMIT_END}")
+done < <(git rev-list --no-merges "${VERIFY_COMMIT_START}..${VERIFY_COMMIT_END}")
 
 # Enforce that at least one commit was verified.
 if [[ "${PERFORMED_VERIFICATION}" == "false" ]]; then


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR tells the CI system to avoid validation of merge commits.  Merge commits typically won't have a sign-off or cryptographic signature, so we want to avoid failing on these if (e.g.) verifying a pull request with merge commits in it.

**Which issue(s) does this pull request address (if any)?**

#69
