### PR TITLE
all: prepare for v0.17.4 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.11'
+          go-version: '1.20.12'
       - name: "Install sha256sum"
         run: brew install coreutils
       - run: scripts/ci/setup_go.sh
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        goversion: ['1.19.13', '1.20.11']
+        goversion: ['1.19.13', '1.20.12']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.20.11'
+          go-version: '1.20.12'
       - run: scripts/ci/setup_go.sh
         shell: bash
       - run: scripts/ci/analyze.sh

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/compose/v2 v2.15.1
 	github.com/docker/docker v20.10.20+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mutagen-io/mutagen v0.17.3
+	github.com/mutagen-io/mutagen v0.17.4
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc h1:yOGQ0Hc3NfO
 github.com/mutagen-io/fsevents v0.0.0-20230629001834-f53e17b91ebc/go.mod h1:kmTyqetTEgYl9KF5JlHLKL6LXnhs2/oK5100pcMZRn8=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c h1:c0xgZ8mF6PwiDc6aW2MEcdaCXxkt5K30kzylWqkT4oc=
 github.com/mutagen-io/gopass v0.0.0-20230214181532-d4b7cdfe054c/go.mod h1:Q87jWQAqEC/UdnYLd+A0mfR9oZl5gk6g/xvxzTpwLv8=
-github.com/mutagen-io/mutagen v0.17.3 h1:JcujOm6PhpBeKzYSamQ65ZlVURCeWyQc96WD642n/9g=
-github.com/mutagen-io/mutagen v0.17.3/go.mod h1:zo/SwmYEaCGSroUUASzff+zKMPiWSYHNXO6E9IQtxXo=
+github.com/mutagen-io/mutagen v0.17.4 h1:Njo5AB6AXpwYLl3U63a/MNz1UT5ERyINfla+rskbMLk=
+github.com/mutagen-io/mutagen v0.17.4/go.mod h1:zo/SwmYEaCGSroUUASzff+zKMPiWSYHNXO6E9IQtxXo=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=


### PR DESCRIPTION
**What does this pull request do and why is it needed?**

This PR updates to Go 1.20.12 and Mutagen v0.17.4.
